### PR TITLE
Remove setup.py setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,0 @@
-[yapf]
-based_on_style = google
-indent_width = 4
-column_limit = 80

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,0 @@
-from setuptools import setup, find_packages
-
-setup(
-    name="chemberta3",
-    version="0.1.0",
-    packages=find_packages(),
-    install_requires=open("requirements.txt").readlines(),
-)


### PR DESCRIPTION
chemberta3 repo by design is a standalone script and not a pip installable library - hence, we don't need setup.py and setup.cfg
