### PR TITLE
Decouple prepare data script from benchmarking script

### DIFF
--- a/chemberta3/benchmarking/benchmark.py
+++ b/chemberta3/benchmarking/benchmark.py
@@ -499,22 +499,6 @@ if __name__ == "__main__":
                            help='evaluate a model',
                            default=False,
                            action='store_true')
-    argparser.add_argument('--prepare_data',
-                           help='parse data',
-                           default=False,
-                           action='store_true')
-    argparser.add_argument('--multicpu_feat',
-                           default=False,
-                           action='store_true',
-                           help='enable multicpu featurization')
-    argparser.add_argument('--csv_path',
-                           help='path to csv file for multi-cpu featurization',
-                           default=None,
-                           type=str)
-    argparser.add_argument('--ncpu',
-                           help='Number of CPUs to use for featurization',
-                           default=None,
-                           type=int)
     argparser.add_argument("--model_name", type=str, default="infograph")
     argparser.add_argument("--task", type=str, default="regression")
     argparser.add_argument("--featurizer_name",
@@ -552,24 +536,7 @@ if __name__ == "__main__":
         logging.basicConfig(filename=os.path.join(exp_dir, 'exp.log'),
                             level=logging.INFO)
 
-    if args.prepare_data:
-        # Pretraining dataset need not be split
-        split_dataset = False if args.pretrain else True
-        if args.multicpu_feat:
-            if args.csv_path is None:
-                raise ValueError(
-                    'Path to csv file for performing featurization is required')
-            if args.ncpu is None:
-                # -1 to leave out a cpu for the master process - the benchmark.py script
-                args.ncpu = os.cpu_count() - 1
-        prepare_data(dataset_name=args.dataset_name,
-                     featurizer_name=args.featurizer_name,
-                     data_dir=args.data_dir,
-                     split_dataset=split_dataset,
-                     is_multicpu_feat=args.multicpu_feat,
-                     csv_path=args.csv_path,
-                     ncpu=args.ncpu)
-    elif args.train or args.pretrain or args.finetune:
+    if args.train or args.pretrain or args.finetune:
         train(args,
               train_data_dir=args.train_data_dir,
               test_data_dir=args.test_data_dir,


### PR DESCRIPTION
In this existing code, `benchmark.py` handles both data preparation and pretraining/finetuning. It is becoming hard to make changes to `benchmark.py`. It will be better if data preparation is handled seperately by another script. This pull request updates `custom_datasets.py` to `prepare_data.py` by making it is a standalone script.
